### PR TITLE
IMPR: Need to test SMTP server credentials

### DIFF
--- a/src/Tasks/SendMailTest.php
+++ b/src/Tasks/SendMailTest.php
@@ -103,8 +103,12 @@ Outcome
 
             $outcome = mail($to, $subject . ' raw mail', $message);
             echo 'PHP mail sent: ' . ($outcome ? 'YES' : 'NO') . $this->newLine();
-            $email = new Email($from, $to, $subject . ' silverstripe message', $message);
-            $outcome = $email->sendPlain();
+            try {
+                $email = new Email($from, $to, $subject . ' silverstripe message', $message);
+                $outcome = $email->sendPlain();
+            } catch(\Exception $e) {
+                die('<div>Mail send error: <span style="color:red">'.$e->getMessage().'</span></div>');
+            }
             echo 'Silverstripe e-mail sent: ' . ($outcome ? 'YES' : 'NO') . $this->newLine();
         }
     }


### PR DESCRIPTION
SilverStripe allows to configure SMTP to send mails.

For example:
```
---
Name: app-mail
After:
- '#emailconfig'
---
SilverStripe\Core\Injector\Injector:
  Swift_Transport:
    class: Swift_SmtpTransport
    properties:
      Host: smtp-host.com
      Port: 587
      Encryption: tls
    calls:
      Username: [ setUsername, ['WRONG@USER'] ]
      Password: [ setPassword, ['WRONG_PASSWORD'] ]
      AuthMode: [ setAuthMode, ['login'] ]
```

If you will try to send an email before this IMPR you will get regular Server Error without any message. So you need to catch it and display the SMTP response. For example: 
```
Failed to authenticate on SMTP server with username "WRONG@USER" using 1 possible authenticators. Authenticator LOGIN returned Expected response code 235 but got code "535", with message "535 5.7.139 Authentication unsuccessful, user password has expired. [CH0P220CA0017.SMTP-HOST.COM 2023-03-23T14:25:29.735Z 08AB2F465BA8AD50] ".
```